### PR TITLE
Corrections and MacOS support

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,8 +5,8 @@ import time
 import urllib.request
 import warnings
 
-from os import system
-import datetime as dt
+import os 
+import datetime 
 
 
 class ExternalResourceHasChanged(Warning):
@@ -58,7 +58,7 @@ def get(location: str, appointment_type: str, num_people: str, date: str) -> str
     except KeyError:
         raise ExternalResourceHasChanged('The IND resource has changed the appointment scheme.')
 
-    if dt.datetime.strptime(earliest_date, '%Y-%m-%d') < dt.datetime.strptime(date, '%d-%m-%Y'):
+    if datetime.datetime.strptime(earliest_date, '%Y-%m-%d') < datetime.datetime.strptime(date, '%d-%m-%Y'):
         return earliest_date
     else:
         return ""
@@ -139,7 +139,7 @@ def main() -> None:
             try:
                 ctypes.windll.user32.MessageBoxW(0, result, 'Appointment found on ' + result, 1)
             except AttributeError:
-                system("osascript -e 'Tell application \"System Events\" to display dialog \"Appointment found on "+ str(result) 
+                os.system("osascript -e 'Tell application \"System Events\" to display dialog \"Appointment found on "+ str(result) 
                        +"\" with title \"Task completed successfully\"'")
            break
         time.sleep(5)

--- a/main.py
+++ b/main.py
@@ -136,12 +136,16 @@ def main() -> None:
     while True:
         result = get(location, appointment_type, num_people, date)
         if result:
-            try:
+            if platform.system() == 'Windows':
                 ctypes.windll.user32.MessageBoxW(0, result, 'Appointment found on ' + result, 1)
-            except AttributeError:
+                break
+            elif platform.system() == 'Darwin':
                 os.system("osascript -e 'Tell application \"System Events\" to display dialog \"Appointment found on "+ str(result) 
                        +"\" with title \"Task completed successfully\"'")
-           break
+                break
+           else:
+                #should probably figure out the way to print system messages on Linux
+                print(f'Appointment found on {result}')
         time.sleep(5)
 
 

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ def get(location: str, appointment_type: str, num_people: str, date: str) -> str
             'There is no appointment slots at all. It is very suspicious. But it can be a temporary problem',
             category=ExternalResourceHasChanged,
         )
+        return ''
     earliest_appointment_info = js[0]
     try:
         earliest_date = earliest_appointment_info['date']

--- a/main.py
+++ b/main.py
@@ -143,9 +143,10 @@ def main() -> None:
                 os.system("osascript -e 'Tell application \"System Events\" to display dialog \"Appointment found on "+ str(result) 
                        +"\" with title \"Task completed successfully\"'")
                 break
-           else:
+            else:
                 #should probably figure out the way to print system messages on Linux
                 print(f'Appointment found on {result}')
+                break
         time.sleep(5)
 
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import urllib.request
 import warnings
 
 from os import system
+import datetime as dt
 
 
 class ExternalResourceHasChanged(Warning):
@@ -57,7 +58,7 @@ def get(location: str, appointment_type: str, num_people: str, date: str) -> str
     except KeyError:
         raise ExternalResourceHasChanged('The IND resource has changed the appointment scheme.')
 
-    if earliest_date < date:
+    if dt.datetime.strptime(earliest_date, '%Y-%m-%d') < dt.datetime.strptime(date, '%d-%m-%Y'):
         return earliest_date
     else:
         return ""

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ import time
 import urllib.request
 import warnings
 
+from os import system
+
 
 class ExternalResourceHasChanged(Warning):
     """Something has been changed on the IND resource"""
@@ -133,8 +135,12 @@ def main() -> None:
     while True:
         result = get(location, appointment_type, num_people, date)
         if result:
-            ctypes.windll.user32.MessageBoxW(0, result, 'Appointment found on ' + result, 1)
-            break
+            try:
+                ctypes.windll.user32.MessageBoxW(0, result, 'Appointment found on ' + result, 1)
+            except AttributeError:
+                system("osascript -e 'Tell application \"System Events\" to display dialog \"Appointment found on "+ str(result) 
+                       +"\" with title \"Task completed successfully\"'")
+           break
         time.sleep(5)
 
 

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 import ctypes
+import datetime
 import json
+import os
+import platform
 import re
 import time
 import urllib.request
 import warnings
-
-import os 
-import datetime 
 
 
 class ExternalResourceHasChanged(Warning):

--- a/main.py
+++ b/main.py
@@ -31,9 +31,11 @@ POSSIBLE_APPOINTMENT_TYPE_LIST = [
 
 
 def get(location: str, appointment_type: str, num_people: str, date: str) -> str:
+    # Not f-string because in such manner
+    # it is easier to copy the template into the browser address line
     url = 'https://oap.ind.nl/oap/api/desks/{}/slots/?productKey={}&persons={}'.format(
         location, appointment_type, num_people,
-    )  # Not f-string because in such manner it is easier to copy the template into the browser address line
+    )
     print('Requesting', url)
     with urllib.request.urlopen(url) as web_content:
         response = web_content.read()
@@ -43,12 +45,15 @@ def get(location: str, appointment_type: str, num_people: str, date: str) -> str
     try:
         js = js['data']
     except KeyError:
-        raise ExternalResourceHasChanged('The IND resource is totally different, no "data" in the response.')
+        raise ExternalResourceHasChanged(
+            'The IND resource is totally different, no "data" in the response.'
+        )
     if not isinstance(js, list):
         raise ExternalResourceHasChanged('The IND resource has changed the data scheme.')
     if not js:
         warnings.warn(
-            'There is no appointment slots at all. It is very suspicious. But it can be a temporary problem',
+            'There is no appointment slots at all. It is very suspicious.'
+            ' But it can be a temporary problem',
             category=ExternalResourceHasChanged,
         )
         return ''
@@ -58,7 +63,10 @@ def get(location: str, appointment_type: str, num_people: str, date: str) -> str
     except KeyError:
         raise ExternalResourceHasChanged('The IND resource has changed the appointment scheme.')
 
-    if datetime.datetime.strptime(earliest_date, '%Y-%m-%d') < datetime.datetime.strptime(date, '%d-%m-%Y'):
+    if (
+            datetime.datetime.strptime(earliest_date, '%Y-%m-%d')
+            < datetime.datetime.strptime(date, '%d-%m-%Y')
+    ):
         return earliest_date
     else:
         return ""
@@ -140,13 +148,15 @@ def main() -> None:
                 ctypes.windll.user32.MessageBoxW(0, result, 'Appointment found on ' + result, 1)
                 break
             elif platform.system() == 'Darwin':
-                os.system("osascript -e 'Tell application \"System Events\" to display dialog \"Appointment found on "+ str(result) 
-                       +"\" with title \"Task completed successfully\"'")
+                os.system(
+                    "osascript -e 'Tell application \"System Events\""
+                    + " to display dialog \"Appointment found on "+ str(result)
+                    + "\" with title \"Task completed successfully\"'"
+                )
                 break
             else:
-                #should probably figure out the way to print system messages on Linux
+                # should probably figure out the way to print system messages on Linux
                 print(f'Appointment found on {result}')
-                break
         time.sleep(5)
 
 


### PR DESCRIPTION
- Added a way for the main function to be exited exactly after getting an empty array from the request, allowing to skip problems with empty array indexation.
- Implemented proper dates comparison using `datetime` module that provides for different date formats in input and json.
- Added support for MacOS (and maybe even linux, but I do not have an opportunity to check) systems by using `os.system` function in case of `ctypes.windll` failing.